### PR TITLE
Use atomic allocation in hashmap test

### DIFF
--- a/tests/concurrent_hash_map_pmreorder_simple/concurrent_hash_map_pmreorder_simple.cpp
+++ b/tests/concurrent_hash_map_pmreorder_simple/concurrent_hash_map_pmreorder_simple.cpp
@@ -45,6 +45,8 @@
 #include <future>
 #include <iostream>
 
+#define LIBPMEMOBJ_CPP_USE_ATOMIC_ALLOCATOR 1
+
 #include <libpmemobj++/experimental/concurrent_hash_map.hpp>
 
 #define LAYOUT "persistent_concurrent_hash_map"


### PR DESCRIPTION
Pmreorder reports some problems when using transactional allocation. This requires some investigation - for now, just run all pmreorder tests with atomic allocations.