### PR TITLE
tests: fix concurrent_map gdb tests

### DIFF
--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb.cpp
@@ -71,6 +71,14 @@ void
 gdb_sync2()
 {
 }
+void
+gdb_sync3()
+{
+}
+void
+gdb_sync_exit()
+{
+}
 
 static int loop_sync_1 = 1;
 static int loop_sync_2 = 1;
@@ -135,38 +143,32 @@ struct test_case_0 : public test_case {
 
 		/* two threads trying to insert the same element and one reader
 		 */
-		parallel_xexec(
-			3,
-			[&](size_t thread_id,
-			    std::function<void(void)> syncthreads) {
-				syncthreads();
+		parallel_exec(3, [&](size_t thread_id) {
+			if (thread_id == 0) {
+				gdb_sync1();
 
-				if (thread_id == 0) {
-					gdb_sync1();
+				r1 = map->emplace(gen_key(*map, mt_insert_key),
+						  gen_key(*map, mt_insert_key));
+			} else if (thread_id == 1) {
+				while (loop_sync_1) {
+					gdb_sync2();
+				};
 
-					r1 = map->emplace(
-						gen_key(*map, mt_insert_key),
-						gen_key(*map, mt_insert_key));
-				} else if (thread_id == 1) {
-					while (loop_sync_1) {
-					};
+				r2 = map->emplace(gen_key(*map, mt_insert_key),
+						  gen_key(*map, mt_insert_key));
+			} else {
+				while (loop_sync_2) {
+					gdb_sync3();
+				};
 
-					r2 = map->emplace(
-						gen_key(*map, mt_insert_key),
-						gen_key(*map, mt_insert_key));
-				} else {
-					while (loop_sync_2) {
-					};
+				pop.root()->reader_status =
+					map->count(gen_key(*map,
+							   mt_insert_key)) == 1;
+				pop.persist(pop.root()->reader_status);
+			}
 
-					pop.root()->reader_status =
-						map->count(gen_key(
-							*map, mt_insert_key)) ==
-						1;
-					pop.persist(pop.root()->reader_status);
-				}
-
-				gdb_sync2();
-			});
+			gdb_sync_exit();
+		});
 	}
 
 	void
@@ -230,38 +232,32 @@ struct test_case_1_2 : public test_case {
 
 		/* two threads trying to insert the same element and one reader
 		 */
-		parallel_xexec(
-			3,
-			[&](size_t thread_id,
-			    std::function<void(void)> syncthreads) {
-				syncthreads();
+		parallel_exec(3, [&](size_t thread_id) {
+			if (thread_id == 0) {
+				gdb_sync1();
 
-				if (thread_id == 0) {
-					gdb_sync1();
+				r1 = map->emplace(gen_key(*map, mt_insert_key),
+						  gen_key(*map, mt_insert_key));
+			} else if (thread_id == 1) {
+				while (loop_sync_1) {
+					gdb_sync2();
+				};
 
-					r1 = map->emplace(
-						gen_key(*map, mt_insert_key),
-						gen_key(*map, mt_insert_key));
-				} else if (thread_id == 1) {
-					while (loop_sync_1) {
-					};
+				r2 = map->emplace(gen_key(*map, mt_insert_key),
+						  gen_key(*map, mt_insert_key));
+			} else {
+				while (loop_sync_2) {
+					gdb_sync3();
+				};
 
-					r2 = map->emplace(
-						gen_key(*map, mt_insert_key),
-						gen_key(*map, mt_insert_key));
-				} else {
-					while (loop_sync_2) {
-					};
+				pop.root()->reader_status =
+					map->count(gen_key(*map,
+							   mt_insert_key)) == 1;
+				pop.persist(pop.root()->reader_status);
+			}
 
-					pop.root()->reader_status =
-						map->count(gen_key(
-							*map, mt_insert_key)) ==
-						1;
-					pop.persist(pop.root()->reader_status);
-				}
-
-				gdb_sync2();
-			});
+			gdb_sync_exit();
+		});
 	}
 
 	void

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_0.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_0.gdb
@@ -21,11 +21,19 @@ thread 10
 c
 set scheduler-locking on
 thread 11
+break gdb_sync2
+c
+del 3
+finish
 set variable loop_sync_1 = 0
 c
 thread 12
+break gdb_sync3
+c
+del 4
+finish
 set variable loop_sync_2 = 0
-break gdb_sync2 thread 12
+break gdb_sync_exit thread 12
 c
 finish
 info threads

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_1.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_1.gdb
@@ -21,12 +21,20 @@ thread 10
 c
 set scheduler-locking on
 thread 11
+break gdb_sync2
+c
+del 4
+finish
 set variable loop_sync_1 = 0
 c
 c
 thread 12
+break gdb_sync3
+c
+del 5
+finish
 set variable loop_sync_2 = 0
-break gdb_sync2 thread 12
+break gdb_sync_exit thread 12
 c
 finish
 info threads

--- a/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_2.gdb
+++ b/tests/concurrent_map_mt_gdb/concurrent_map_mt_gdb_2.gdb
@@ -20,6 +20,10 @@ thread 10
 c
 set scheduler-locking on
 thread 11
+break gdb_sync2
+c
+del 3
+finish
 set variable loop_sync_1 = 0
 c
 break set_next
@@ -29,10 +33,14 @@ finish
 finish
 n
 n
-del 3
+del 4
 thread 12
+break gdb_sync3
+c
+del 5
+finish
 set variable loop_sync_2 = 0
-break gdb_sync2 thread 12
+break gdb_sync_exit thread 12
 c
 finish
 info threads


### PR DESCRIPTION
when thread with id == 0 hit gdb_sync1 other threads might have not
arrived at spin loops. Fix that by explicitly waiting for those threads
using additional sync points.